### PR TITLE
feat: step1 of atom components stories

### DIFF
--- a/components/atoms/Profile/ProfileIcon.tsx
+++ b/components/atoms/Profile/ProfileIcon.tsx
@@ -17,8 +17,7 @@ import {
 
 interface IProfileIcon {
   user: IUser | IUserRegisterForm | "guest" | "ABOUT";
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  size: any;
+  size: keyof typeof ICON_SIZE;
   isMember?: boolean;
   isImagePriority?: boolean;
 }

--- a/components/atoms/skeleton/Skeleton.tsx
+++ b/components/atoms/skeleton/Skeleton.tsx
@@ -1,17 +1,15 @@
-import { Skeleton as ChakraSkeleton } from "@chakra-ui/react";
+import { Skeleton as ChakraSkeleton, SkeletonProps } from "@chakra-ui/react";
+import { PropsWithChildren } from "react";
 
-interface ISkeleton {
-  children: React.ReactNode;
-  isLoad?: boolean;
-}
+interface ISkeleton extends Pick<SkeletonProps, "isLoaded"> {}
 
-function Skeleton({ children, isLoad }: ISkeleton) {
+function Skeleton({ children, isLoaded = false }: PropsWithChildren<ISkeleton>) {
   return (
     <ChakraSkeleton
       borderRadius="8px"
       startColor="RGB(227, 230, 235)"
       endColor="rgb(246,247,249)"
-      isLoaded={isLoad}
+      isLoaded={isLoaded}
       height="100%"
       width="100%"
     >

--- a/modals/aboutHeader/promotionModal/PromotionModalDetail.tsx
+++ b/modals/aboutHeader/promotionModal/PromotionModalDetail.tsx
@@ -23,7 +23,7 @@ function PromotionModalDetail() {
       <div>
         <span>현재 참여 수</span>
         <VoteNum>
-          <Skeleton isLoad={!isLoading}>
+          <Skeleton isLoaded={!isLoading}>
             {applyCnt || ""}명<Temp>(중복 포함)</Temp>
           </Skeleton>
         </VoteNum>

--- a/stories/atoms/badges/Badge.stories.ts
+++ b/stories/atoms/badges/Badge.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Badge } from "../../../components/atoms/badges/Badges";
 
 const meta = {
-  title: "ATOMS/Button/Badge",
+  title: "Atoms/Badge/Badge",
   component: Badge,
   parameters: {},
   tags: ["autodocs"],

--- a/stories/atoms/badges/Badge.stories.ts
+++ b/stories/atoms/badges/Badge.stories.ts
@@ -5,14 +5,11 @@ import { Badge } from "../../../components/atoms/badges/Badges";
 const meta = {
   title: "Atoms/Badge/Badge",
   component: Badge,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof Badge>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/badges/OutlineBadge.stories.ts
+++ b/stories/atoms/badges/OutlineBadge.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import OutlineBadge from "../../../components/atoms/badges/OutlineBadge";
+
+const meta = {
+  title: "Atoms/Badge/OutlineBadge",
+  component: OutlineBadge,
+  parameters: {},
+  tags: ["autodocs"],
+  argTypes: {},
+
+  args: {},
+} satisfies Meta<typeof OutlineBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    colorScheme: "mintTheme",
+    text: "OutlineBadge",
+  },
+};
+
+export const PrimarySizeSmall: Story = {
+  args: {
+    ...Primary.args,
+    size: "sm",
+  },
+};

--- a/stories/atoms/badges/OutlineBadge.stories.ts
+++ b/stories/atoms/badges/OutlineBadge.stories.ts
@@ -5,14 +5,11 @@ import OutlineBadge from "../../../components/atoms/badges/OutlineBadge";
 const meta = {
   title: "Atoms/Badge/OutlineBadge",
   component: OutlineBadge,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof OutlineBadge>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/blocks/IconButtonColBlock.stories.tsx
+++ b/stories/atoms/blocks/IconButtonColBlock.stories.tsx
@@ -1,0 +1,42 @@
+import { faLock } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import IconButtonColBlock from "../../../components/atoms/blocks/IconButtonColBlock";
+
+const meta = {
+  title: "Atoms/Blocks/IconButtonColBlock",
+  component: IconButtonColBlock,
+  parameters: {},
+  tags: ["autodocs"],
+  argTypes: {},
+
+  args: {},
+} satisfies Meta<typeof IconButtonColBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    props: {
+      icon: <FontAwesomeIcon icon={faLock} color="var(--gray-3)" />,
+      title: "I'm title prop",
+      buttonProp: {
+        text: "I'm Button's text prop",
+        func: () => {},
+      },
+      disabled: false,
+    },
+  },
+};
+
+export const PrimaryDisabled: Story = {
+  args: {
+    ...Primary.args,
+    props: {
+      ...Primary.args.props,
+      disabled: true,
+    },
+  },
+};

--- a/stories/atoms/blocks/IconButtonColBlock.stories.tsx
+++ b/stories/atoms/blocks/IconButtonColBlock.stories.tsx
@@ -7,14 +7,11 @@ import IconButtonColBlock from "../../../components/atoms/blocks/IconButtonColBl
 const meta = {
   title: "Atoms/Blocks/IconButtonColBlock",
   component: IconButtonColBlock,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof IconButtonColBlock>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/buttons/ArrowBackButton.stories.ts
+++ b/stories/atoms/buttons/ArrowBackButton.stories.ts
@@ -5,14 +5,11 @@ import { ArrowBackButtonUI } from "../../../components/atoms/buttons/ArrowBackBu
 const meta = {
   title: "ATOMS/Button/ArrowBackButton",
   component: ArrowBackButtonUI,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof ArrowBackButtonUI>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/buttons/ArrowTextButton.stories.ts
+++ b/stories/atoms/buttons/ArrowTextButton.stories.ts
@@ -5,14 +5,11 @@ import ArrowTextButton from "../../../components/atoms/buttons/ArrowTextButton";
 const meta = {
   title: "ATOMS/Button/ArrowTextButton",
   component: ArrowTextButton,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof ArrowTextButton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/buttons/BasicButton.stories.ts
+++ b/stories/atoms/buttons/BasicButton.stories.ts
@@ -6,7 +6,6 @@ import { BasicButton } from "../../../components/atoms/buttons/BasicButton";
 const meta = {
   title: "ATOMS/Button/BasicButton",
   component: BasicButton,
-  parameters: {},
   tags: ["autodocs"],
   argTypes: {
     backgroundColor: { control: "color" },
@@ -16,6 +15,7 @@ const meta = {
 } satisfies Meta<typeof BasicButton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/buttons/HighlightedTextButton.stories.ts
+++ b/stories/atoms/buttons/HighlightedTextButton.stories.ts
@@ -5,14 +5,11 @@ import HighlightedTextButton from "../../../components/atoms/buttons/Highlighted
 const meta = {
   title: "ATOMS/Button/HighlightedTextButton",
   component: HighlightedTextButton,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof HighlightedTextButton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/buttons/ShadowBlockButton.stories.ts
+++ b/stories/atoms/buttons/ShadowBlockButton.stories.ts
@@ -5,14 +5,11 @@ import ShadowBlockButton from "../../../components/atoms/buttons/ShadowBlockButt
 const meta = {
   title: "ATOMS/Button/ShadowBlockButton",
   component: ShadowBlockButton,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof ShadowBlockButton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/buttons/ShadowCircleButton.stories.ts
+++ b/stories/atoms/buttons/ShadowCircleButton.stories.ts
@@ -5,14 +5,11 @@ import ShadowCircleButton from "../../../components/atoms/buttons/ShadowCircleBu
 const meta = {
   title: "ATOMS/Button/ShadowCircleButton",
   component: ShadowCircleButton,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof ShadowCircleButton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/loaders/MainLoading.stories.tsx
+++ b/stories/atoms/loaders/MainLoading.stories.tsx
@@ -5,14 +5,11 @@ import { MainLoading } from "../../../components/atoms/loaders/MainLoading";
 const meta = {
   title: "Atoms/Loaders/MainLoading",
   component: MainLoading,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof MainLoading>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/loaders/MainLoading.stories.tsx
+++ b/stories/atoms/loaders/MainLoading.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { MainLoading } from "../../../components/atoms/loaders/MainLoading";
+
+const meta = {
+  title: "Atoms/Loaders/MainLoading",
+  component: MainLoading,
+  parameters: {},
+  tags: ["autodocs"],
+  argTypes: {},
+
+  args: {},
+} satisfies Meta<typeof MainLoading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {},
+};

--- a/stories/atoms/profile/ProfileIcon.stories.tsx
+++ b/stories/atoms/profile/ProfileIcon.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import ProfileIcon from "../../../components/atoms/Profile/ProfileIcon";
+
+const meta = {
+  title: "Atoms/Profile/ProfileIcon",
+  component: ProfileIcon,
+  parameters: {},
+  tags: ["autodocs"],
+  argTypes: {},
+
+  args: {},
+} satisfies Meta<typeof ProfileIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    user: "ABOUT",
+    size: "md",
+  },
+};

--- a/stories/atoms/profile/ProfileIcon.stories.tsx
+++ b/stories/atoms/profile/ProfileIcon.stories.tsx
@@ -5,14 +5,11 @@ import ProfileIcon from "../../../components/atoms/Profile/ProfileIcon";
 const meta = {
   title: "Atoms/Profile/ProfileIcon",
   component: ProfileIcon,
-  parameters: {},
   tags: ["autodocs"],
-  argTypes: {},
-
-  args: {},
 } satisfies Meta<typeof ProfileIcon>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/atoms/skeletons/Skeleton.stories.tsx
+++ b/stories/atoms/skeletons/Skeleton.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Skeleton from "../../../components/atoms/skeleton/Skeleton";
+
+const meta = {
+  title: "Atoms/skeleton/Skeleton",
+  component: Skeleton,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    children: "I'm Skeleton's children",
+  },
+};

--- a/stories/atoms/skeletons/Skeleton.stories.tsx
+++ b/stories/atoms/skeletons/Skeleton.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
 } satisfies Meta<typeof Skeleton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {

--- a/stories/molecules/Accordion.stories.ts
+++ b/stories/molecules/Accordion.stories.ts
@@ -4,7 +4,7 @@ import Accordion from "../../components/molecules/Accordion";
 import { ACCORDION_CONTENT_FEE } from "../../constants/contentsText/accordionContents";
 
 const meta = {
-  title: "ATOMS/molecules/Accordion",
+  title: "Molecules/Accordion",
   component: Accordion,
   parameters: {},
   tags: ["autodocs"],

--- a/stories/molecules/Accordion.stories.ts
+++ b/stories/molecules/Accordion.stories.ts
@@ -4,7 +4,7 @@ import Accordion from "../../components/molecules/Accordion";
 import { ACCORDION_CONTENT_FEE } from "../../constants/contentsText/accordionContents";
 
 const meta = {
-  title: "Molecules/Accordion",
+  title: "ATOMS/molecules/Accordion",
   component: Accordion,
   parameters: {},
   tags: ["autodocs"],


### PR DESCRIPTION
closes #112 

## 🤷‍♂️ 작업 내용

<!-- 작업 내용에 대한 설명 -->

- Atom 컴포넌트 중 순차적으로 스토리 작성 중입니다.

## 📒 특이 사항

<!-- 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항 -->

### 스토리 작성하지 않은 컴포넌트
- `UserBadge` : 유저 정보로 생각되는(?) `uid` 를 받고 있어서 특정하게 스타일을 작성해주기 곤란했습니다. 그래서 스토리에서 제외했어요

### 논의하고 싶은 점
- `IconButtonColBlock` props 네이밍
  - `<IconButtonColBlock props={...} />` 으로 작성되어 있는 코드를 보면 `props`가 어떤 props인지 알 수 없어요. 결국 코드를 뜯어봐야해요. 개발하면서 코드 뜯어보는 건 개발을 지체하게 만들어요 (곰곰이 생각해보면 경험해보셨을거에요.) 그래서 props 네이밍을 명확하게 수정하는 방향으로 가면 어떨까요?

### Props 수정
- `Skeleton` props 를 `isLoad`을 `isLoaded`로 수정했어요. 그리고 Chakra의 `SkeletonProps` 타입을 상속했어요. `Skeleton`이 `ChakraSkeleton`을 한번 wrapping한 컴포넌트이기 때문에 Chakra와 인터페이스를 동일하게 가져가려는 의도입니다. 그리고 chakra의 tsdoc 주석을 최대한 이용하고자 하는 목적입니다.
<img width="562" alt="스크린샷 2024-05-01 15 27 17" src="https://github.com/AboutClan/About/assets/33178048/d29c383b-0b62-4bf6-a582-5d0685ff6248">

## 📷 스크린샷

<!-- 작업 결과물 -->

## 작업시간
- 예상시간: 1시간
- 실제시간: 1시간
