### PR TITLE
fix: optimize rendering - home study section

### DIFF
--- a/pageTemplates/home/HomeStudySection.tsx
+++ b/pageTemplates/home/HomeStudySection.tsx
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import { AnimatePresence, motion, PanInfo } from "framer-motion";
-import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
@@ -51,8 +51,11 @@ export default function HomeStudySection() {
   const { mutate: decideStudyResult } = useStudyResultDecideMutation(date);
 
   useEffect(() => {
-    if (!studyVoteData || !studyVoteData.length || !session?.user) return;
-
+    if (!studyVoteData || !studyVoteData.length || !session?.user || !studyDateStatus) {
+      setStudyCardColData(null);
+      return;
+    }
+    console.log(1, studyVoteData, studyDateStatus);
     const sortedData = sortStudyVoteData(studyVoteData, studyDateStatus !== "not passed");
 
     const cardList = setStudyDataToCardCol(sortedData, date as string, session?.user.uid);


### PR DESCRIPTION
문제: 홈 화면에서 스터디 섹션이 두번 렌더링 되어서 번쩍임

문제 원인 및 해결방법: 날짜가 변하는 경우 studyDateStatus를 초기화하고 있었는데, studyCardColData는 따로 초기화가 안되고 있어서 완전히 바뀌기 전에 렌더링이 이전값으로 되고 있었음. useEffect의 return 조건에 studyDateStatus가 없는 경우를 추가하고, 이 경우에는 studyCardColData를 null로 변환함 