### PR TITLE
Refactor/page slider #131

### DIFF
--- a/components/atoms/buttons/ArrowBackButton.tsx
+++ b/components/atoms/buttons/ArrowBackButton.tsx
@@ -1,24 +1,16 @@
 import { faChevronLeft } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter } from "next/navigation";
-import { useRecoilState, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
-import { prevPageUrlState, slideDirectionState } from "../../../recoils/navigationRecoils";
 interface IArrowBackButton {
   url?: string;
 }
 export default function ArrowBackButton({ url }: IArrowBackButton) {
   const router = useRouter();
-  const [prevPageUrl, setPrevPageUrl] = useRecoilState(prevPageUrlState);
-  const setSlideDirection = useSetRecoilState(slideDirectionState);
 
   const handleGoBack = () => {
-    setSlideDirection("left");
-    if (prevPageUrl) {
-      router.push(prevPageUrl);
-      setPrevPageUrl(null);
-    } else if (url) router.push(url);
+    if (url) router.push(url);
     else router.back();
   };
 

--- a/components/layouts/PageSlide.tsx
+++ b/components/layouts/PageSlide.tsx
@@ -11,7 +11,7 @@ interface IPageLayout {
 
 function Slide({ children, isFixed, posZero }: IPageLayout) {
   const [slideDirection, setSlideDirection] = useRecoilState(slideDirectionState);
-
+  console.log(slideDirection, 4);
   useEffect(() => {
     return () => {
       setSlideDirection("right");

--- a/components/layouts/PageSlide.tsx
+++ b/components/layouts/PageSlide.tsx
@@ -11,11 +11,9 @@ interface IPageLayout {
 
 function Slide({ children, isFixed, posZero }: IPageLayout) {
   const [slideDirection, setSlideDirection] = useRecoilState(slideDirectionState);
-  console.log(slideDirection, 4);
+
   useEffect(() => {
-    return () => {
-      setSlideDirection("right");
-    };
+    setSlideDirection("right");
   }, []);
 
   const variants = {
@@ -28,6 +26,7 @@ function Slide({ children, isFixed, posZero }: IPageLayout) {
       opacity: 1,
     },
   };
+
   const animationProps = slideDirection
     ? {
         initial: "hidden",
@@ -37,6 +36,7 @@ function Slide({ children, isFixed, posZero }: IPageLayout) {
         transition: { duration: 0.5 },
       }
     : {};
+ 
   return (
     <>
       <motion.div

--- a/components/layouts/PageTracker.tsx
+++ b/components/layouts/PageTracker.tsx
@@ -1,0 +1,161 @@
+import { usePathname } from "next/navigation";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useSetRecoilState } from "recoil";
+
+import { BASE_BOTTOM_NAV_SEGMENT } from "../../pageTemplates/layout/Layout";
+import { slideDirectionState } from "../../recoils/navigationRecoils";
+import { parseUrlToSegments } from "../../utils/stringUtils";
+
+const GATHER_WRITING_SEQUENCE = {
+  category: 1,
+  content: 2,
+  date: 3,
+  location: 4,
+  condition: 5,
+};
+
+const GROUP_WRITING_SEQUENCE = {
+  main: 1,
+  sub: 2,
+  guide: 3,
+  content: 4,
+  period: 5,
+  hasgTag: 6,
+  condition: 7,
+};
+
+function PageTracker() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const setSlideDirection = useSetRecoilState(slideDirectionState);
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    const determineSlideDirection = (currentSegments, prevSegments) => {
+      const curFirstSegment = currentSegments[0];
+
+      const setLeftSlide = () => setSlideDirection("left");
+      const setRightSlide = () => setSlideDirection("right");
+
+      switch (curFirstSegment) {
+        case "home":
+          setLeftSlide();
+          break;
+
+        case "study":
+          if (prevSegments[0] !== "home" && prevSegments[0] !== "studyList") {
+            setLeftSlide();
+          }
+          break;
+
+        case "user":
+          if (!currentSegments[1] && prevSegments[0] !== "home") {
+            setLeftSlide();
+          }
+          break;
+
+        case "event":
+          if (!currentSegments[1] && prevSegments[0] !== "home") {
+            setLeftSlide();
+          }
+          break;
+
+        case "store":
+          if (!currentSegments[1] && prevSegments[0] !== "event") {
+            setLeftSlide();
+          }
+          break;
+
+        case "member":
+          if (!currentSegments[2] && prevSegments[0] !== "home") {
+            setLeftSlide();
+          }
+          break;
+
+        case "gather":
+          handleWritingPage(
+            GATHER_WRITING_SEQUENCE,
+            currentSegments,
+            prevSegments,
+            setLeftSlide,
+            setRightSlide,
+          );
+          break;
+
+        case "group":
+          handleWritingPage(
+            GROUP_WRITING_SEQUENCE,
+            currentSegments,
+            prevSegments,
+            setLeftSlide,
+            setRightSlide,
+          );
+          break;
+
+        default:
+          break;
+      }
+    };
+
+    const handleWritingPage = (
+      pageSequence,
+      currentSegments,
+      prevSegments,
+      setLeftSlide,
+      setRightSlide,
+    ) => {
+      if (!currentSegments[1]) {
+        setLeftSlide();
+      } else if (currentSegments[1] === "writing") {
+        if (!prevSegments[2]) {
+          setRightSlide();
+        } else {
+          const prevCategoryValue = pageSequence[prevSegments[2]];
+          const curCategoryValue = pageSequence[currentSegments[2]];
+
+          if (prevCategoryValue < curCategoryValue) {
+            setRightSlide();
+          } else {
+            setLeftSlide();
+          }
+        }
+      }
+    };
+
+    const handleRouterStart = (url) => {
+      if (!url || !pathname) return;
+      const prevSegments = parseUrlToSegments(pathname);
+      const currentSegments = parseUrlToSegments(url);
+
+      if (
+        prevSegments[0] !== currentSegments[0] &&
+        BASE_BOTTOM_NAV_SEGMENT.includes(prevSegments[0]) &&
+        BASE_BOTTOM_NAV_SEGMENT.includes(currentSegments[0])
+      ) {
+        setSlideDirection(null);
+        return;
+      }
+
+      determineSlideDirection(currentSegments, prevSegments);
+    };
+
+    const handleRouterCompleted = (url) => {
+      if (url) {
+        setSlideDirection("right");
+      }
+    };
+
+    router.events.on("routeChangeStart", handleRouterStart);
+    router.events.on("routeChangeComplete", handleRouterCompleted);
+    return () => {
+      router.events.off("routeChangeStart", handleRouterStart);
+      router.events.off("routeChangeComplete", handleRouterCompleted);
+    };
+  }, [router.events, pathname, setSlideDirection]);
+
+  return null;
+}
+
+export default PageTracker;

--- a/modals/home/writeDrawer.tsx
+++ b/modals/home/writeDrawer.tsx
@@ -51,7 +51,7 @@ export default function WriteDrawer() {
               color="red.400"
             />
             <SocialButton
-              url="/group/writing/category/main"
+              url="/group/writing/main"
               title="소그룹"
               subTitle="비슷한 관심사의 인원들을 모아봐요"
               icon={<FontAwesomeIcon icon={faCampfire} color="white" />}

--- a/pageTemplates/gather/detail/GatherHeader.tsx
+++ b/pageTemplates/gather/detail/GatherHeader.tsx
@@ -5,13 +5,12 @@ import dayjs from "dayjs";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
 import Header from "../../../components/layouts/Header";
 import GatherKakaoShareModal from "../../../modals/gather/GatherKakaoShareModal";
 import { isGatherEditState } from "../../../recoils/checkAtoms";
-import { prevPageUrlState } from "../../../recoils/previousAtoms";
 import { sharedGatherWritingState } from "../../../recoils/sharedDataAtoms";
 import { IGather } from "../../../types/models/gatherTypes/gatherTypes";
 import { IUserSummary } from "../../../types/models/userTypes/userInfoTypes";
@@ -30,20 +29,18 @@ function GatherHeader({ gatherData }: IGatherHeader) {
   const { data: session } = useSession();
   const setGatherWriting = useSetRecoilState(sharedGatherWritingState);
   const setIsGatherEdit = useSetRecoilState(isGatherEditState);
-  const [prevPageUrl, setPrevPageUrl] = useRecoilState(prevPageUrlState);
 
   const [isModal, setIsModal] = useState(false);
 
   const onClick = () => {
     setGatherWriting({ ...gatherData, date: dayjs(gatherData.date) });
     setIsGatherEdit(true);
-    setPrevPageUrl(`/gather/${router.query.id}`);
     router.push("/gather/writing/category");
   };
 
   return (
     <>
-      <Header title="" url={prevPageUrl || "/gather"}>
+      <Header title="">
         <Flex>
           {session?.user.uid === (organizer as IUserSummary)?.uid && (
             <IconWrapper onClick={onClick}>

--- a/pageTemplates/group/detail/GroupHeader.tsx
+++ b/pageTemplates/group/detail/GroupHeader.tsx
@@ -39,7 +39,7 @@ function GroupHeader({ group }: IGroupHeader) {
   const onClick = () => {
     setGroupWriting(group);
 
-    router.push("/group/writing/category/main");
+    router.push("/group/writing/main");
   };
 
   const movePage = async () => {

--- a/pages/gather/[id]/index.tsx
+++ b/pages/gather/[id]/index.tsx
@@ -34,32 +34,29 @@ function GatherDetail() {
 
   return (
     <>
-      <GatherHeader gatherData={gatherData} />
-
-      <>
-        {gatherData ? (
-          <>
-            <Slide>
-              <Layout>
-                <GatherOrganizer
-                  createdAt={gatherData.createdAt}
-                  organizer={gatherData.user as IUserSummary}
-                  isAdminOpen={gatherData.isAdminOpen}
-                  category={gatherData.type.title}
-                />
-                <GatherDetailInfo data={gatherData} />
-                <GatherTitle title={gatherData.title} status={gatherData.status} />
-                <GatherContent content={gatherData.content} gatherList={gatherData.gatherList} />
-                <GatherParticipation data={gatherData} />
-                <GatherComments comment={gatherData.comment} />
-              </Layout>
-            </Slide>
-            {!isGuest && <GatherBottomNav data={gatherData} />}
-          </>
-        ) : (
-          <MainLoading />
-        )}
-      </>
+      {gatherData ? (
+        <>
+          <GatherHeader gatherData={gatherData} />
+          <Slide>
+            <Layout>
+              <GatherOrganizer
+                createdAt={gatherData.createdAt}
+                organizer={gatherData.user as IUserSummary}
+                isAdminOpen={gatherData.isAdminOpen}
+                category={gatherData.type.title}
+              />
+              <GatherDetailInfo data={gatherData} />
+              <GatherTitle title={gatherData.title} status={gatherData.status} />
+              <GatherContent content={gatherData.content} gatherList={gatherData.gatherList} />
+              <GatherParticipation data={gatherData} />
+              <GatherComments comment={gatherData.comment} />
+            </Layout>
+          </Slide>
+          {!isGuest && <GatherBottomNav data={gatherData} />}
+        </>
+      ) : (
+        <MainLoading />
+      )}
     </>
   );
 }

--- a/pages/gather/index.tsx
+++ b/pages/gather/index.tsx
@@ -29,7 +29,7 @@ function Gather() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
+  console.log(444);
   return (
     <>
       <GatherHeader />

--- a/pages/gather/index.tsx
+++ b/pages/gather/index.tsx
@@ -29,7 +29,6 @@ function Gather() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  console.log(444);
   return (
     <>
       <GatherHeader />

--- a/pages/group/index.tsx
+++ b/pages/group/index.tsx
@@ -180,7 +180,7 @@ function Index() {
           </>
         </Layout>
       </Slide>
-      {!isGuest && <WritingIcon url="/group/writing/category/main" />}
+      {!isGuest && <WritingIcon url="/group/writing/main" />}
 
       {isRuleModal && <RuleModal content={GROUP_STUDY_RULE_CONTENT} setIsModal={setIsRuleModal} />}
     </>

--- a/pages/group/writing/guide.tsx
+++ b/pages/group/writing/guide.tsx
@@ -40,7 +40,7 @@ function GroupWritingGuide() {
     <>
       <Slide isFixed={true}>
         <ProgressStatus value={42} />
-        <Header isSlide={false} title="" url="/group/writing/category/sub" />
+        <Header isSlide={false} title="" url="/group/writing/sub" />
       </Slide>
 
       <RegisterLayout>

--- a/pages/group/writing/main.tsx
+++ b/pages/group/writing/main.tsx
@@ -3,18 +3,18 @@ import { useState } from "react";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
-import BottomNav from "../../../../components/layouts/BottomNav";
-import Header from "../../../../components/layouts/Header";
-import Slide from "../../../../components/layouts/PageSlide";
-import ProgressStatus from "../../../../components/molecules/ProgressStatus";
+import BottomNav from "../../../components/layouts/BottomNav";
+import Header from "../../../components/layouts/Header";
+import Slide from "../../../components/layouts/PageSlide";
+import ProgressStatus from "../../../components/molecules/ProgressStatus";
 import {
   GROUP_STUDY_CATEGORY_ARR,
   GROUP_STUDY_CATEGORY_ARR_ICONS,
-} from "../../../../constants/contentsText/GroupStudyContents";
-import { useFailToast } from "../../../../hooks/custom/CustomToast";
-import RegisterLayout from "../../../../pageTemplates/register/RegisterLayout";
-import RegisterOverview from "../../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../../recoils/sharedDataAtoms";
+} from "../../../constants/contentsText/GroupStudyContents";
+import { useFailToast } from "../../../hooks/custom/CustomToast";
+import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
+import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
+import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
 function WritingStudyCategoryMain() {
   const router = useRouter();
   const failToast = useFailToast();
@@ -32,7 +32,7 @@ function WritingStudyCategoryMain() {
       ...old,
       category: { ...old?.category, main: category },
     }));
-    router.push(`/group/writing/category/sub`);
+    router.push(`/group/writing/sub`);
   };
 
   return (

--- a/pages/group/writing/sub.tsx
+++ b/pages/group/writing/sub.tsx
@@ -3,18 +3,18 @@ import { useEffect, useState } from "react";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
-import BottomNav from "../../../../components/layouts/BottomNav";
-import Header from "../../../../components/layouts/Header";
-import Slide from "../../../../components/layouts/PageSlide";
-import ProgressStatus from "../../../../components/molecules/ProgressStatus";
+import BottomNav from "../../../components/layouts/BottomNav";
+import Header from "../../../components/layouts/Header";
+import Slide from "../../../components/layouts/PageSlide";
+import ProgressStatus from "../../../components/molecules/ProgressStatus";
 import {
   GROUP_STUDY_CATEGORY_ARR_ICONS,
   GROUP_STUDY_SUB_CATEGORY,
-} from "../../../../constants/contentsText/GroupStudyContents";
-import { useFailToast } from "../../../../hooks/custom/CustomToast";
-import RegisterLayout from "../../../../pageTemplates/register/RegisterLayout";
-import RegisterOverview from "../../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../../recoils/sharedDataAtoms";
+} from "../../../constants/contentsText/GroupStudyContents";
+import { useFailToast } from "../../../hooks/custom/CustomToast";
+import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
+import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
+import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
 function WritingStudyCategorySub() {
   const router = useRouter();
   const failToast = useFailToast();
@@ -38,7 +38,7 @@ function WritingStudyCategorySub() {
   };
 
   useEffect(() => {
-    if (!mainCategory) router.push("/group/writing/category/main");
+    if (!mainCategory) router.push("/group/writing/main");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mainCategory]);
 
@@ -46,7 +46,7 @@ function WritingStudyCategorySub() {
     <>
       <Slide isFixed={true}>
         <ProgressStatus value={28} />
-        <Header isSlide={false} title="" url="/group/writing/category/main" />
+        <Header isSlide={false} title="" url="/group/writing/main" />
       </Slide>
 
       <RegisterLayout>

--- a/pages/member/[location]/index.tsx
+++ b/pages/member/[location]/index.tsx
@@ -111,31 +111,32 @@ function Member() {
   return (
     <>
       <MemberHeader />
+      <Slide>
+        {groupedMembers ? (
+          <>
+            <SectionBar title="멤버 소개" size="md" />
+            <Box mx="16px">
+              {MEMBER_SECTIONS.map((section) => {
+                if (section === "birth" && groupedMembers.birth.length === 0) return;
+                return (
+                  <Section key={section}>
+                    <MemberSectionTitle section={section} onClickSection={onClickSection} />
+                    <BlurredPart isBlur={isGuest}>
+                      <MemberSectionList members={groupedMembers[section]} />
+                    </BlurredPart>
+                  </Section>
+                );
+              })}
 
-      {groupedMembers ? (
-        <Slide>
-          <SectionBar title="멤버 소개" size="md" />
-          <Box mx="16px">
-            {MEMBER_SECTIONS.map((section) => {
-              if (section === "birth" && groupedMembers.birth.length === 0) return;
-              return (
-                <Section key={section}>
-                  <MemberSectionTitle section={section} onClickSection={onClickSection} />
-                  <BlurredPart isBlur={isGuest}>
-                    <MemberSectionList members={groupedMembers[section]} />
-                  </BlurredPart>
-                </Section>
-              );
-            })}
-
-            <HrDiv />
-          </Box>
-          <MemberRecommend members={locationMembers} />
-        </Slide>
-      ) : (
-        <MainLoading />
-        // <MemberSkeleton />
-      )}
+              <HrDiv />
+            </Box>
+            <MemberRecommend members={locationMembers} />
+          </>
+        ) : (
+          <MainLoading />
+          // <MemberSkeleton />
+        )}
+      </Slide>
     </>
   );
 }

--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -8,3 +8,11 @@ export const findParentheses = (text: string) => {
     return null; // 일치하는 결과가 없을 경우의 메시지
   }
 };
+
+export const parseUrlToSegments = (url) => {
+  if (!url) return null;
+  const queryStartIndex = url.indexOf("?");
+  const basePath = queryStartIndex >= 0 ? url.substring(0, queryStartIndex) : url;
+  const segments = basePath.split("/").filter(Boolean);
+  return segments;
+};


### PR DESCRIPTION
#131 

문제 해결

1. 각 페이지 이동간에 state 로직 최소화
2. layout 페이지에서 route 이동 경로를 추적하여 slide animation 결정

알게 된 거

1. router events 에서 beforeHistoryChange, routeChangeComplete, routeChangeStart
 => 적용 순서는 routeStart -> historyChange -> routeComplete

2. layout은 page간에 공통으로 유지되고 있기 때문에 페이지가 전환되었더라도 useEffect가 다시 한번 실행되지 않는다 (의존 인자까지 변경되어야 실행된다)

고민했던 거

1. 안드로이드 어플, 아이폰 어플들에서 애니매이션은 어떻게 적용되고 있는지
=> 아이폰은 기본 동작으로 애니매이션 슬라이드가 정해져있다. (모두 동일)
=> 안드로이드는 고정된 애니매이션이 없기 때문에 어플마다, 상황마다 다른 애니매이션을 개발자가 직접 설정한다

2. 뒤로가기나 앞으로 가는 상황
=> 버튼을 눌러서 이동하는 경우 쉽게 핸들링을 할 수 있지만, 웹상의 기능이 아닌 모바일에서 뒤로가기 버튼을 누른 경우 핸들링을 어떻게 해야 할지.
=> history를 결국 추적할 필요가 있었고 처음에는 state를 통해 prev, current를 기록하려고 했음. 
=> 페이지마다 작업해야 해서 관리가 어렵고, state는 비동기이기 때문에 애니매이션 적용이 느렸음
=> a -> b -> c -> b ->a 순서로 이동하는 경우, back router을 통해서는 무한 루프에 빠지게 되는 경우가 있음. 이는 직접 테스트를 하면서 케이스 파악이 필요했음

3. bottom NAV에서 이동하는 경우에는 애니매이션을 주고 싶지 않았음. 
4. history를 따로 저장하면서 pop 하는 방식도 고민해봤음

