### PR TITLE
feat: image loader 작성

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const withPWA = require("next-pwa");
 const runtimeCaching = require("next-pwa/cache");
 const nextConfig = {
   images: {
+    loaderFile: "/utils/imageLoader.ts",
     remotePatterns: [
       {
         protocol: "https",

--- a/utils/imageLoader.ts
+++ b/utils/imageLoader.ts
@@ -1,0 +1,17 @@
+const s3Origin = "https://studyabout.s3.ap-northeast-2.amazonaws.com";
+
+export default function loader({ src, width, quality }) {
+  const url = new URL(src);
+  const isS3Url = url.origin === s3Origin;
+
+  if (isS3Url) {
+    return `https://d15r8f9iey54a4.cloudfront.net${url.pathname}`;
+  }
+
+  // NOTE
+  // Next.js에 의해 최적화된 이미지를 요청하는 URL
+  // S3가 아닌 나머지 이미지는 최적화를 거쳐 웹서버에서 이미지를 가져오도록 함
+  // Next.js 내부 구현에 의존한거라 Hacky한 방식
+  return `/_next/image/?url=${encodeURIComponent(src)}&w=${width}&q=${quality || 75}`;
+}
+``;


### PR DESCRIPTION
## Background

- s3 이미지의 경우 cloudfront에 cache 되도록 하고자 함.
- CDN은 앞으로 충분히 바뀔 여지가 있어 DB에서 url을 모두 수정해야하는 것은 비효율적임
- next.js의 loader를 통해 s3 이미지만 cloudfront 에서 이미지를 가져오도록 함. 나머지 이미지는 웹서버(next 서버)에서 최적화된 이미지를 사용

## PR Point

- s3와 cloudfront origin을 환경변수로 관리해야할지 고민됩니다. 저는 추가해도 괜찮다고 생각합니다! 왜냐하면 환경변수로 관리하면 origin이 바뀔 시 **코드 수정 없이** 환경변수만 바꿔서 재배포하면 되기 때문입니다.
- s3 이미지는 최적화되지 않고 바로 cloudfront에서 가져옵니다. 최적화가 필요하면 따로 최적화를 구현해야합니다!