### PR TITLE
fix: disable scroll restoration when dragging study lists

### DIFF
--- a/pageTemplates/home/study/HomeStudyChart.tsx
+++ b/pageTemplates/home/study/HomeStudyChart.tsx
@@ -30,7 +30,6 @@ function HomeStudyChart({ voteCntArr }: HomeStudyChartProps) {
   const locationArr = [];
   const xArr = [];
   filtered?.forEach((obj) => {
-    console.log(obj);
     totalArr.push(obj.totalValue);
     locationArr.push(obj.value);
     xArr.push(dayjs(obj.date).date() + "");

--- a/pageTemplates/home/study/HomeStudyCol.tsx
+++ b/pageTemplates/home/study/HomeStudyCol.tsx
@@ -126,7 +126,7 @@ export default function HomeStudyCol() {
     const newDate = getNewDateBySwipe(panInfo, date as string);
     if (newDate !== date) {
       newSearchParams.set("date", newDate);
-      router.replace(`/home?${newSearchParams.toString()}`);
+      router.replace(`/home?${newSearchParams.toString()}`, { scroll: false });
     }
     return;
   };

--- a/pageTemplates/home/study/studyController/StudyController.tsx
+++ b/pageTemplates/home/study/studyController/StudyController.tsx
@@ -59,7 +59,7 @@ function StudyController({
     setSelectedDate(date);
   }, [date]);
 
-  const onClick = (moveDate: string) => {
+  const handleSelectDate = (moveDate: string) => {
     if (date === moveDate) return;
     setStudyDateStatus(undefined);
     newSearchParams.set("date", moveDate);
@@ -101,7 +101,7 @@ function StudyController({
                   <WeekSlideCalendar
                     voteCntArr={voteCntArr}
                     selectedDate={selectedDateDayjs}
-                    func={onClick}
+                    func={handleSelectDate}
                   />
                 </Flex>
                 <StudyControllerVoteButton


### PR DESCRIPTION
## Why

- 메인 홈화면에서 스터디 목록 드래그할 때마다 스크롤이 회복(restoration)되어 매끄럽지 못한 사용자 경험을 주었어요.

## TODO

- `HomeStudyCol` 컴포넌트에서 드래그 시 scroll restoration을 막아두었어요

## AS-IS/TO-BE

### AS-IS

https://github.com/AboutClan/About/assets/33178048/db9a586c-afc2-42af-8e69-746049e41c14

### TO-BE

https://github.com/AboutClan/About/assets/33178048/0a199775-ab95-4fbf-9c5e-787a765b1483


