### PR TITLE
perf and refactor: group-writing

### DIFF
--- a/components/atoms/Avatar.tsx
+++ b/components/atoms/Avatar.tsx
@@ -34,7 +34,7 @@ export default function Avatar({
   const hasAvatar = avatar !== undefined && avatar?.type !== null && avatar?.bg !== null;
 
   const [imageUrl, setImageUrl] = useState(!hasAvatar ? image : AVATAR_IMAGE_ARR[avatar.type]);
-  console.log(14, AVATAR_IMAGE_ARR[avatar?.type]);
+
   useEffect(() => {
     setImageUrl(!hasAvatar ? image : AVATAR_IMAGE_ARR[avatar.type]);
   }, [image, avatar]);

--- a/constants/keys/localStorage.ts
+++ b/constants/keys/localStorage.ts
@@ -29,6 +29,7 @@ export const ENTHUSIASTIC_POP_UP = "enthusiasticPopUp";
 export const RABBIT_RUN = "rabbitRun";
 
 export const REGISTER_INFO = "registerInfo";
+export const GROUP_WRITING_STORE = "groupWritingStore";
 
 export const USER_GUIDE = "useGuide";
 export const VOTE_GUIDE = "voteGuide";

--- a/modals/gather/GatherWritingUserConditionModal.tsx
+++ b/modals/gather/GatherWritingUserConditionModal.tsx
@@ -4,14 +4,16 @@ import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import { PopOverIcon } from "../../components/atoms/Icons/PopOverIcon";
+import { GROUP_WRITING_STORE } from "../../constants/keys/localStorage";
 import { GatherConditionType } from "../../pages/gather/writing/condition";
 import { GroupConditionType } from "../../pages/group/writing/condition";
 import GatherWritingConditionAgeRange from "../../pageTemplates/gather/writing/condition/GatherWritingConditionAgeRange";
 import GatherWritingConditionCnt from "../../pageTemplates/gather/writing/condition/GatherWritingConditionCnt";
-import { sharedGatherWritingState, sharedGroupWritingState } from "../../recoils/sharedDataAtoms";
+import { sharedGatherWritingState } from "../../recoils/sharedDataAtoms";
 import { IModal } from "../../types/components/modalTypes";
 import { IGatherMemberCnt, IGatherWriting } from "../../types/models/gatherTypes/gatherTypes";
 import { IGroupWriting } from "../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../utils/storageUtils";
 import { ModalLayout } from "../Modals";
 
 interface GatherWritingUserConditionModalProps extends IModal {
@@ -33,19 +35,26 @@ function GatherWritingUserConditionModal({
   type,
 }: GatherWritingUserConditionModalProps) {
   const [gatherContent, setGatherContent] = useRecoilState(sharedGatherWritingState);
-  const [groupContent, setGroupContent] = useRecoilState(sharedGroupWritingState);
-
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
+  
   const [memberCnt, setMemberCnt] = useState<IGatherMemberCnt>(
-    gatherContent?.memberCnt || {
-      min: 4,
-      max: 0,
-    },
+    gatherContent?.memberCnt ||
+      groupWriting?.memberCnt || {
+        min: 4,
+        max: 0,
+      },
   );
   const [age, setAge] = useState(gatherContent?.age || [19, 28]);
 
   useEffect(() => {
     if (type === "gather") setGatherContent({ ...gatherContent, age, memberCnt });
-    if (type === "group") setGroupContent({ ...groupContent, age, memberCnt });
+    if (type === "group") {
+      setLocalStorageObj(GROUP_WRITING_STORE, {
+        ...groupWriting,
+        age,
+        memberCnt,
+      });
+    }
   }, [age, memberCnt]);
 
   return (

--- a/modals/groupStudy/WritingConfirmModal.tsx
+++ b/modals/groupStudy/WritingConfirmModal.tsx
@@ -20,6 +20,17 @@ interface IGroupConfirmModal extends IModal {
   setGroupWriting: DispatchType<IGroupWriting>;
 }
 
+const REQUIRED_FIELDS = [
+  "category",
+  "title",
+  "content",
+  "guide",
+  "gender",
+  "location",
+  "memberCnt",
+  "age",
+];
+
 function GroupConfirmModal({ setIsModal, setGroupWriting, groupWriting }: IGroupConfirmModal) {
   const router = useRouter();
   const errorToast = useErrorToast();
@@ -49,7 +60,7 @@ function GroupConfirmModal({ setIsModal, setGroupWriting, groupWriting }: IGroup
     },
     onError: errorToast,
   });
-
+  console.log(25, groupWriting);
   const onSubmit = () => {
     if (groupWriting?.id) {
       updateGroup({ groupStudy: groupWriting as IGroup });

--- a/modals/groupStudy/WritingConfirmModal.tsx
+++ b/modals/groupStudy/WritingConfirmModal.tsx
@@ -4,6 +4,7 @@ import { useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
 import SuccessScreen from "../../components/layouts/SuccessScreen";
+import { GROUP_WRITING_STORE } from "../../constants/keys/localStorage";
 import { GROUP_STUDY_ALL } from "../../constants/keys/queryKeys";
 import { useResetQueryData } from "../../hooks/custom/CustomHooks";
 import { useCompleteToast, useErrorToast } from "../../hooks/custom/CustomToast";
@@ -11,27 +12,14 @@ import { useGroupWritingMutation } from "../../hooks/groupStudy/mutations";
 import { transferGroupDataState } from "../../recoils/transferRecoils";
 import { ModalSubtitle } from "../../styles/layout/modal";
 import { IModal } from "../../types/components/modalTypes";
-import { DispatchType } from "../../types/hooks/reactTypes";
 import { IGroup, IGroupWriting } from "../../types/models/groupTypes/group";
 import { IFooterOptions, ModalLayout } from "../Modals";
 
 interface IGroupConfirmModal extends IModal {
   groupWriting: IGroupWriting;
-  setGroupWriting: DispatchType<IGroupWriting>;
 }
 
-const REQUIRED_FIELDS = [
-  "category",
-  "title",
-  "content",
-  "guide",
-  "gender",
-  "location",
-  "memberCnt",
-  "age",
-];
-
-function GroupConfirmModal({ setIsModal, setGroupWriting, groupWriting }: IGroupConfirmModal) {
+function GroupConfirmModal({ setIsModal, groupWriting }: IGroupConfirmModal) {
   const router = useRouter();
   const errorToast = useErrorToast();
   const completeToast = useCompleteToast();
@@ -40,18 +28,22 @@ function GroupConfirmModal({ setIsModal, setGroupWriting, groupWriting }: IGroup
   const setGroup = useSetRecoilState(transferGroupDataState);
   const resetQueryData = useResetQueryData();
 
+  const resetLocalStorage = () => {
+    localStorage.setItem(GROUP_WRITING_STORE, null);
+  };
+
   const { mutate } = useGroupWritingMutation("post", {
     onSuccess() {
       resetQueryData([GROUP_STUDY_ALL]);
       setGroup(null);
-      setGroupWriting(null);
+      resetLocalStorage();
       setIsSuccessScreen(true);
     },
     onError: errorToast,
   });
   const { mutate: updateGroup } = useGroupWritingMutation("patch", {
     onSuccess() {
-      setGroupWriting(null);
+      resetLocalStorage();
       setGroup(null);
       completeToast("free", "수정되었습니다.");
       resetQueryData([GROUP_STUDY_ALL], () => {
@@ -60,7 +52,7 @@ function GroupConfirmModal({ setIsModal, setGroupWriting, groupWriting }: IGroup
     },
     onError: errorToast,
   });
-  console.log(25, groupWriting);
+
   const onSubmit = () => {
     if (groupWriting?.id) {
       updateGroup({ groupStudy: groupWriting as IGroup });

--- a/pageTemplates/gather/writing/condition/GatherWritingConditionCnt.tsx
+++ b/pageTemplates/gather/writing/condition/GatherWritingConditionCnt.tsx
@@ -30,7 +30,7 @@ function GatherWritingConditionCnt({ isMin, value, setMemberCnt }: IGatherWritin
       setNumber(4);
     } else setMemberCnt((old) => ({ ...old, max: 0 }));
   };
-
+ 
   return (
     <Layout>
       <MemberCnt>

--- a/pageTemplates/group/detail/GroupComment.tsx
+++ b/pageTemplates/group/detail/GroupComment.tsx
@@ -62,7 +62,7 @@ function GroupComments({ comment }: IGroupComments) {
     setCommentText(text);
     setIsEditModal(true);
   };
-  console.log(25, userInfo);
+
   return (
     <>
       <Layout>

--- a/pageTemplates/group/detail/GroupHeader.tsx
+++ b/pageTemplates/group/detail/GroupHeader.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "@chakra-ui/react";
-import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
 import { useState } from "react";
 import styled from "styled-components";
 
@@ -34,9 +34,9 @@ function GroupHeader({ group }: IGroupHeader) {
 
   const onClick = () => {
     setLocalStorageObj(GROUP_WRITING_STORE, {
-      group,
+      ...group,
     });
-    router.push(`/group/writing/main?id=${group.id}`);
+    router.push(`/group/writing/main`);
   };
 
   const movePage = async () => {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -144,7 +144,7 @@ export const authOptions: NextAuthOptions = {
             isActive: false,
             profileImage: "",
           };
-          console.log(25, account, token);
+        
           return token;
         }
 
@@ -174,7 +174,7 @@ export const authOptions: NextAuthOptions = {
             isActive: user.isActive,
             location: account.location || user.location,
           };
-          console.log(13, newToken);
+         
           return newToken;
         }
 

--- a/pages/group/index.tsx
+++ b/pages/group/index.tsx
@@ -16,6 +16,7 @@ import {
   GROUP_STUDY_RULE_CONTENT,
   GROUP_STUDY_SUB_CATEGORY,
 } from "../../constants/contentsText/GroupStudyContents";
+import { GROUP_WRITING_STORE } from "../../constants/keys/localStorage";
 import { useGroupQuery } from "../../hooks/groupStudy/queries";
 import RuleModal from "../../modals/RuleModal";
 import GroupBlock from "../../pageTemplates/group/GroupBlock";
@@ -54,6 +55,7 @@ function Index() {
   const { data: groups, isLoading } = useGroupQuery();
 
   useEffect(() => {
+    localStorage.setItem(GROUP_WRITING_STORE, null);
     setCategory({
       main: categoryIdx !== null ? GROUP_STUDY_CATEGORY_ARR[categoryIdx] : "전체",
       sub: null,
@@ -103,9 +105,6 @@ function Index() {
       );
     }
 
-
- 
-
     const filtered =
       category.main === "전체"
         ? groups
@@ -145,7 +144,7 @@ function Index() {
 
   return (
     <>
-    <Header title="소모임" url="/home" isBack={false}>
+      <Header title="소모임" url="/home" isBack={false}>
         <RuleIcon setIsModal={setIsRuleModal} />
       </Header>
 

--- a/pages/group/writing/condition.tsx
+++ b/pages/group/writing/condition.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Flex, Switch } from "@chakra-ui/react";
 import { useSession } from "next-auth/react";
 import { ChangeEvent, useEffect, useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import { PopOverIcon } from "../../../components/atoms/Icons/PopOverIcon";
@@ -10,6 +9,7 @@ import BottomNav from "../../../components/layouts/BottomNav";
 import Header from "../../../components/layouts/Header";
 import Slide from "../../../components/layouts/PageSlide";
 import ProgressStatus from "../../../components/molecules/ProgressStatus";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import { useUserInfoQuery } from "../../../hooks/user/queries";
 import GatherWritingUserConditionModal from "../../../modals/gather/GatherWritingUserConditionModal";
 import GroupConfirmModal from "../../../modals/groupStudy/WritingConfirmModal";
@@ -17,9 +17,9 @@ import GatherWritingConditionLocation from "../../../pageTemplates/gather/writin
 import QuestionBottomDrawer from "../../../pageTemplates/group/writing/QuestionBottomDrawer";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
 import { IGroupWriting } from "../../../types/models/groupTypes/group";
 import { Location, LocationFilterType } from "../../../types/services/locationTypes";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 
 export type GroupConditionType =
   | "gender"
@@ -35,7 +35,8 @@ export type GroupConditionType =
 export type CombinedLocation = "전체" | "수원/안양" | "양천/강남";
 
 function WritingCondition() {
-  const [groupWriting, setGroupWriting] = useRecoilState(sharedGroupWritingState);
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
+
   const { data: session } = useSession();
 
   const { data: userInfo } = useUserInfoQuery();
@@ -55,12 +56,12 @@ function WritingCondition() {
       groupWriting?.fee !== undefined
         ? groupWriting?.fee !== 200 && groupWriting?.fee !== 0
         : false,
-    kakaoUrl: false,
-    isSecret: false,
+
+    isSecret: groupWriting?.isSecret || false,
   });
 
   const [challenge, setChallenge] = useState("");
-  const [kakaoUrl, setKakaoUrl] = useState<string>("");
+
   const [fee, setFee] = useState(groupWriting?.fee || "1000");
   const [feeText, setFeeText] = useState(groupWriting?.feeText || "기본 참여비");
 
@@ -71,6 +72,7 @@ function WritingCondition() {
   const [isConfirmModal, setIsConfirmModal] = useState(false);
   const [isMemberConditionModal, setIsMemberConditionModal] = useState(false);
   const [isQuestionModal, setIsQuestionModal] = useState(false);
+  const [link, setLink] = useState(groupWriting?.link || "");
 
   useEffect(() => {
     if (!condition.isFree) setIsQuestionModal(true);
@@ -89,14 +91,17 @@ function WritingCondition() {
       feeText,
       isFree: condition.isFree,
       location: location || userInfo?.location,
-      link: kakaoUrl,
+      link,
       gender: condition.gender,
       organizer: userInfo,
       questionText: question,
       isSecret: condition.isSecret,
       challenge,
     };
-    setGroupWriting(groupData);
+
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupData,
+    });
     setIsConfirmModal(true);
   };
 
@@ -125,13 +130,13 @@ function WritingCondition() {
     if (condition.gender) {
       temp.push("성별");
     }
-    if (groupWriting?.memberCnt.max) {
+    if (groupWriting?.memberCnt?.max) {
       temp.push("인원");
     }
     if (temp.length) return String(temp) + " " + "제한";
     return null;
   };
-
+ 
   return (
     <>
       <Slide isFixed={true}>
@@ -261,11 +266,11 @@ function WritingCondition() {
               <Switch
                 mr="var(--gap-1)"
                 colorScheme="mintTheme"
-                isChecked={condition.kakaoUrl}
+                isChecked={!!link}
                 onChange={(e) => toggleSwitch(e, "kakaoUrl")}
               />
             </Item>{" "}
-            {condition.kakaoUrl && (
+            {link && (
               <Flex align="center" mr="4px">
                 <Box
                   fontSize="12px"
@@ -277,7 +282,7 @@ function WritingCondition() {
                 >
                   URL
                 </Box>
-                <Input size="sm" value={kakaoUrl} onChange={(e) => setKakaoUrl(e.target.value)} />
+                <Input size="sm" value={link} onChange={(e) => setLink(e.target.value)} />
               </Flex>
             )}
           </Container>
@@ -291,11 +296,7 @@ function WritingCondition() {
         setQuestion={setQuestion}
       />
       {isConfirmModal && (
-        <GroupConfirmModal
-          setIsModal={setIsConfirmModal}
-          groupWriting={groupWriting}
-          setGroupWriting={setGroupWriting}
-        />
+        <GroupConfirmModal setIsModal={setIsConfirmModal} groupWriting={groupWriting} />
       )}{" "}
       {isMemberConditionModal && (
         <GatherWritingUserConditionModal

--- a/pages/group/writing/condition.tsx
+++ b/pages/group/writing/condition.tsx
@@ -42,7 +42,11 @@ function WritingCondition() {
 
   const [condition, setCondition] = useState({
     gender: groupWriting?.gender || false,
-    age: groupWriting?.age ? true : false,
+    age: !groupWriting?.age
+      ? false
+      : groupWriting.age[0] === 19 && groupWriting.age[1] === 28
+        ? false
+        : true,
     isFree: groupWriting?.isFree !== undefined ? groupWriting?.isFree : true,
     location:
       groupWriting?.location !== undefined ? groupWriting?.location === userInfo?.location : true,
@@ -121,10 +125,11 @@ function WritingCondition() {
     if (condition.gender) {
       temp.push("성별");
     }
-    if (groupWriting?.memberCnt) {
+    if (groupWriting?.memberCnt.max) {
       temp.push("인원");
     }
-    return String(temp) + " " + "제한";
+    if (temp.length) return String(temp) + " " + "제한";
+    return null;
   };
 
   return (

--- a/pages/group/writing/content.tsx
+++ b/pages/group/writing/content.tsx
@@ -1,40 +1,37 @@
-import { useRouter } from "next/router";
 import { useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import BottomNav from "../../../components/layouts/BottomNav";
 import Header from "../../../components/layouts/Header";
 import Slide from "../../../components/layouts/PageSlide";
 import ProgressStatus from "../../../components/molecules/ProgressStatus";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import { useFailToast } from "../../../hooks/custom/CustomToast";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
+import { IGroupWriting } from "../../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 
 function GroupWritingContent() {
-  const router = useRouter();
   const failToast = useFailToast();
 
-  const [group, setGroup] = useRecoilState(sharedGroupWritingState);
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
 
-  //초기 input 세팅
-
-  const [content, setContent] = useState(group?.content || "");
-  const [rules, setRules] = useState<string[]>(group?.rules?.length ? group?.rules : [""]);
+  const [content, setContent] = useState(groupWriting?.content || "");
+  const [rules, setRules] = useState<string[]>(
+    groupWriting?.rules?.length ? groupWriting?.rules : [""],
+  );
 
   const onClickNext = () => {
     if (!content) {
       failToast("free", "내용을 작성해 주세요!", true);
       return;
     }
-
-    setGroup((old) => ({
-      ...old,
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupWriting,
       rules: rules[0] === "" ? [] : rules,
       content,
-    }));
-    router.push(`/group/writing/period`);
+    });
   };
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>, idx: number) => {
@@ -92,7 +89,7 @@ function GroupWritingContent() {
         </Container>
       </RegisterLayout>
 
-      <BottomNav onClick={() => onClickNext()} />
+      <BottomNav onClick={() => onClickNext()} url="/group/writing/period" />
     </>
   );
 }

--- a/pages/group/writing/guide.tsx
+++ b/pages/group/writing/guide.tsx
@@ -1,39 +1,35 @@
-import { useRouter } from "next/router";
 import { useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import BottomNav from "../../../components/layouts/BottomNav";
 import Header from "../../../components/layouts/Header";
 import Slide from "../../../components/layouts/PageSlide";
 import ProgressStatus from "../../../components/molecules/ProgressStatus";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import { useFailToast } from "../../../hooks/custom/CustomToast";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
+import { IGroupWriting } from "../../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 
 function GroupWritingGuide() {
-  const router = useRouter();
   const failToast = useFailToast();
 
-  const [group, setGroup] = useRecoilState(sharedGroupWritingState);
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
 
-  //초기 input 세팅
-  const [title, setTitle] = useState(group?.title || "");
-  const [guide, setGuide] = useState(group?.guide || "");
+  const [title, setTitle] = useState(groupWriting?.title || "");
+  const [guide, setGuide] = useState(groupWriting?.guide || "");
 
   const onClickNext = () => {
     if (!title || !guide) {
       failToast("free", "내용을 작성해 주세요!", true);
       return;
     }
-
-    setGroup((old) => ({
-      ...old,
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupWriting,
       title,
       guide,
-    }));
-    router.push(`/group/writing/content`);
+    });
   };
 
   return (
@@ -58,7 +54,7 @@ function GroupWritingGuide() {
         </Container>
       </RegisterLayout>
 
-      <BottomNav onClick={() => onClickNext()} />
+      <BottomNav onClick={() => onClickNext()} url="/group/writing/content" />
     </>
   );
 }

--- a/pages/group/writing/hashTag.tsx
+++ b/pages/group/writing/hashTag.tsx
@@ -1,36 +1,33 @@
-import { useRouter } from "next/router";
 import { useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import BottomNav from "../../../components/layouts/BottomNav";
 import Header from "../../../components/layouts/Header";
 import Slide from "../../../components/layouts/PageSlide";
 import ProgressStatus from "../../../components/molecules/ProgressStatus";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import { useFailToast } from "../../../hooks/custom/CustomToast";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
+import { IGroupWriting } from "../../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 
 function GroupWritingHashTag() {
-  const router = useRouter();
   const failToast = useFailToast();
 
-  const [group, setGroup] = useRecoilState(sharedGroupWritingState);
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
 
-  const [text, setText] = useState(group?.hashTag || "");
+  const [text, setText] = useState(groupWriting?.hashTag || "");
 
   const onClickNext = () => {
     if (!text) {
       failToast("free", "내용을 작성해 주세요!", true);
       return;
     }
-
-    setGroup((old) => ({
-      ...old,
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupWriting,
       hashTag: text,
-    }));
-    router.push(`/group/writing/condition`);
+    });
   };
 
   return (
@@ -54,7 +51,7 @@ function GroupWritingHashTag() {
         </Container>
       </RegisterLayout>
 
-      <BottomNav onClick={() => onClickNext()} />
+      <BottomNav onClick={() => onClickNext()} url="/group/writing/condition" />
     </>
   );
 }

--- a/pages/group/writing/main.tsx
+++ b/pages/group/writing/main.tsx
@@ -58,7 +58,7 @@ function WritingStudyCategoryMain() {
         </ItemContainer>
       </RegisterLayout>
 
-      <BottomNav onClick={onClickNext} />
+      <BottomNav onClick={onClickNext} url={`/group/writing/sub/$`} />
     </>
   );
 }

--- a/pages/group/writing/main.tsx
+++ b/pages/group/writing/main.tsx
@@ -1,6 +1,4 @@
-import { useRouter } from "next/router";
 import { useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import BottomNav from "../../../components/layouts/BottomNav";
@@ -11,15 +9,16 @@ import {
   GROUP_STUDY_CATEGORY_ARR,
   GROUP_STUDY_CATEGORY_ARR_ICONS,
 } from "../../../constants/contentsText/GroupStudyContents";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import { useFailToast } from "../../../hooks/custom/CustomToast";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
+import { IGroupWriting } from "../../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 function WritingStudyCategoryMain() {
-  const router = useRouter();
   const failToast = useFailToast();
 
-  const [groupWriting, setgroupWriting] = useRecoilState(sharedGroupWritingState);
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
 
   const [category, setCategory] = useState<string>(groupWriting?.category?.main);
 
@@ -28,11 +27,10 @@ function WritingStudyCategoryMain() {
       failToast("free", "주제를 선택해 주세요!", true);
       return;
     }
-    setgroupWriting((old) => ({
-      ...old,
-      category: { ...old?.category, main: category },
-    }));
-    router.push(`/group/writing/sub`);
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupWriting,
+      category: { ...groupWriting?.category, main: category },
+    });
   };
 
   return (
@@ -58,7 +56,7 @@ function WritingStudyCategoryMain() {
         </ItemContainer>
       </RegisterLayout>
 
-      <BottomNav onClick={onClickNext} url={`/group/writing/sub/$`} />
+      <BottomNav onClick={onClickNext} url="/group/writing/sub" />
     </>
   );
 }

--- a/pages/group/writing/period.tsx
+++ b/pages/group/writing/period.tsx
@@ -1,6 +1,4 @@
-import { useRouter } from "next/router";
 import { useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import BottomNav from "../../../components/layouts/BottomNav";
@@ -8,24 +6,21 @@ import Header from "../../../components/layouts/Header";
 import Slide from "../../../components/layouts/PageSlide";
 import ButtonCheckNav from "../../../components/molecules/ButtonCheckNav";
 import ProgressStatus from "../../../components/molecules/ProgressStatus";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
+import { IGroupWriting } from "../../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 function GroupWritingContent() {
-  const router = useRouter();
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
 
-  const [group, setGroup] = useRecoilState(sharedGroupWritingState);
-
-  const [period, setPeriod] = useState(group?.period || "주 1회");
-
-  //초기 input 세팅
+  const [period, setPeriod] = useState(groupWriting?.period || "주 1회");
 
   const onClickNext = () => {
-    setGroup((old) => ({
-      ...old,
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupWriting,
       period,
-    }));
-    router.push(`/group/writing/hashTag`);
+    });
   };
 
   const periodArr = [
@@ -48,7 +43,6 @@ function GroupWritingContent() {
         <ProgressStatus value={72} />
         <Header isSlide={false} title="" url="/group/writing/content" />
       </Slide>
-
       <RegisterLayout>
         <RegisterOverview>
           <span>진행 주기를 체크해주세요!</span>
@@ -63,8 +57,7 @@ function GroupWritingContent() {
           />
         </Container>
       </RegisterLayout>
-
-      <BottomNav onClick={() => onClickNext()} />
+      <BottomNav onClick={() => onClickNext()} url="/group/writing/hashTag" />
     </>
   );
 }

--- a/pages/group/writing/sub.tsx
+++ b/pages/group/writing/sub.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import BottomNav from "../../../components/layouts/BottomNav";
@@ -11,35 +10,35 @@ import {
   GROUP_STUDY_CATEGORY_ARR_ICONS,
   GROUP_STUDY_SUB_CATEGORY,
 } from "../../../constants/contentsText/GroupStudyContents";
+import { GROUP_WRITING_STORE } from "../../../constants/keys/localStorage";
 import { useFailToast } from "../../../hooks/custom/CustomToast";
 import RegisterLayout from "../../../pageTemplates/register/RegisterLayout";
 import RegisterOverview from "../../../pageTemplates/register/RegisterOverview";
-import { sharedGroupWritingState } from "../../../recoils/sharedDataAtoms";
+import { IGroupWriting } from "../../../types/models/groupTypes/group";
+import { setLocalStorageObj } from "../../../utils/storageUtils";
 function WritingStudyCategorySub() {
   const router = useRouter();
   const failToast = useFailToast();
 
-  const [GroupWriting, setGroupWriting] = useRecoilState(sharedGroupWritingState);
+  const groupWriting: IGroupWriting = JSON.parse(localStorage.getItem(GROUP_WRITING_STORE));
 
-  const mainCategory = GroupWriting?.category?.main;
+  const mainCategory = groupWriting?.category?.main;
 
-  const [category, setCategory] = useState<string>(GroupWriting?.category?.sub);
+  const [category, setCategory] = useState<string>(groupWriting?.category?.sub);
 
   const onClickNext = () => {
     if (!category) {
       failToast("free", "주제를 선택해 주세요!", true);
       return;
     }
-    setGroupWriting((old) => ({
-      ...old,
-      category: { ...old.category, sub: category },
-    }));
-    router.push(`/group/writing/guide`);
+    setLocalStorageObj(GROUP_WRITING_STORE, {
+      ...groupWriting,
+      category: { ...groupWriting?.category, sub: category },
+    });
   };
 
   useEffect(() => {
     if (!mainCategory) router.push("/group/writing/main");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mainCategory]);
 
   return (
@@ -48,7 +47,6 @@ function WritingStudyCategorySub() {
         <ProgressStatus value={28} />
         <Header isSlide={false} title="" url="/group/writing/main" />
       </Slide>
-
       <RegisterLayout>
         <RegisterOverview>
           <span>주제를 선택해 주세요.</span>
@@ -63,7 +61,7 @@ function WritingStudyCategorySub() {
         </ItemContainer>
       </RegisterLayout>
 
-      <BottomNav onClick={onClickNext} />
+      <BottomNav onClick={onClickNext} url="/group/writing/guide" />
     </>
   );
 }

--- a/pages/group/writing/sub.tsx
+++ b/pages/group/writing/sub.tsx
@@ -54,7 +54,7 @@ function WritingStudyCategorySub() {
           <span>주제를 선택해 주세요.</span>
         </RegisterOverview>
         <ItemContainer>
-          {GROUP_STUDY_SUB_CATEGORY[mainCategory].map((type, idx) => (
+          {GROUP_STUDY_SUB_CATEGORY?.[mainCategory]?.map((type, idx) => (
             <Item key={idx} isSelected={type === category} onClick={() => setCategory(type)}>
               <IconWrapper>{GROUP_STUDY_CATEGORY_ARR_ICONS[mainCategory]}</IconWrapper>
               <Info>{type}</Info>


### PR DESCRIPTION
**제목:**
소모임 게시글 작성 및 수정 부분 리팩토링

**상세 설명:** 
게시글 작성시 총 6페이지 이상, 십여개의 필드를 포함해 작성하게 되는데 기존에는 이를 global-state로 다뤘음. 하지만 이렇게 했을때 중간에 새로고침이 되는 상황이 발생하면 앞서 작성한 데이터가 날아가거서 적용되지 않거나, id를 알 수 없어서 게시글 수정인데 새로 생성되는 등의 문제가 발생.

**문제해결**
회원가입 페이지와 마찬가지로 global state대신 localstorage를 활용하여 저장하면서 진행하는 방식으로 변경. 이 과정에서 몇몇 오류 해결과 성능개선, 리팩토링을 진행함. 작업을 완료했거나, 혹은 작업중 그냥 종료하는 경우 localstorage를 리셋해줬음. 