### PR TITLE
perf: gather participate

### DIFF
--- a/constants/serviceConstants/pointSystemConstants.ts
+++ b/constants/serviceConstants/pointSystemConstants.ts
@@ -19,7 +19,6 @@ export const POINT_SYSTEM_PLUS = {
   DAILY_ATTEND: { value: 2, message: "일일 출석" },
   PROMOTION: { value: 100, message: "홍보 리워드" },
   LIKE: { value: 2, message: "좋아요" },
-  GATHER_ATTEND: { value: 5, message: "모임 참여" },
 };
 
 export const POINT_SYSTEM_DEPOSIT = {

--- a/modals/InviteUserModal.tsx
+++ b/modals/InviteUserModal.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { useQueryClient } from "react-query";
 
+import { Input } from "../components/atoms/Input";
 import { MainLoadingAbsolute } from "../components/atoms/loaders/MainLoading";
 import ButtonGroups from "../components/molecules/groups/ButtonGroups";
 import InviteUserGroups from "../components/molecules/groups/InviteUserGroups";
@@ -14,6 +15,7 @@ import { useGatherParticipationMutation } from "../hooks/gather/mutations";
 import { IModal } from "../types/components/modalTypes";
 import { IUserSummary } from "../types/models/userTypes/userInfoTypes";
 import { ActiveLocation } from "../types/services/locationTypes";
+import { searchName } from "../utils/stringUtils";
 import { IFooterOptions, ModalLayout } from "./Modals";
 
 interface IInviteUserModal extends IModal {}
@@ -26,12 +28,11 @@ export default function InviteUserModal({ setIsModal }: IInviteUserModal) {
   const [location, setLocation] = useState<ActiveLocation>(session?.user.location || "수원");
   const [inviteUser, setInviteUser] = useState<IUserSummary>(null);
   const [users, setUsers] = useState<IUserSummary[]>(null);
+  const [nameValue, setNameValue] = useState("");
 
-  const {
-    data: usersAll,
-
-    isLoading,
-  } = useAdminUsersLocationControlQuery(location, null, true, { enabled: true });
+  const { data: usersAll, isLoading } = useAdminUsersLocationControlQuery(location, null, true, {
+    enabled: true,
+  });
 
   const queryClient = useQueryClient();
 
@@ -43,8 +44,9 @@ export default function InviteUserModal({ setIsModal }: IInviteUserModal) {
   });
 
   useEffect(() => {
-    setUsers(usersAll);
-  }, [usersAll]);
+    if (nameValue) setUsers(searchName(usersAll, nameValue));
+    else setUsers(usersAll);
+  }, [nameValue, usersAll]);
 
   useEffect(() => {
     if (!inviteUser) return;
@@ -89,7 +91,14 @@ export default function InviteUserModal({ setIsModal }: IInviteUserModal) {
   return (
     <ModalLayout setIsModal={setIsModal} title="인원 초대" footerOptions={footerOptions}>
       <ButtonGroups buttonDataArr={buttonDataArr} currentValue={location} />
-
+      <Box mt="16px">
+        <Input
+          placeholder="이름 검색"
+          size="xs"
+          value={nameValue}
+          onChange={(e) => setNameValue(e.target.value)}
+        />
+      </Box>
       <Box
         h="300px"
         overflowY="auto"

--- a/modals/gather/gatherParticipateModal/GatherParticipateModalParticipate.tsx
+++ b/modals/gather/gatherParticipateModal/GatherParticipateModalParticipate.tsx
@@ -1,11 +1,9 @@
 import { useRouter } from "next/router";
 
 import { GATHER_CONTENT } from "../../../constants/keys/queryKeys";
-import { POINT_SYSTEM_PLUS } from "../../../constants/serviceConstants/pointSystemConstants";
 import { useResetQueryData } from "../../../hooks/custom/CustomHooks";
 import { useCompleteToast, useErrorToast } from "../../../hooks/custom/CustomToast";
 import { useGatherParticipationMutation } from "../../../hooks/gather/mutations";
-import { usePointSystemMutation } from "../../../hooks/user/mutations";
 import { IModal } from "../../../types/components/modalTypes";
 import { ModalBodyNavTwo } from "../../Modals";
 
@@ -18,12 +16,9 @@ function GatherParticipateModalParticipate({ setIsModal }: IModal) {
 
   const resetQueryData = useResetQueryData();
 
-  const { mutate: getScore } = usePointSystemMutation("score");
-
   const { mutate: participate } = useGatherParticipationMutation("post", gatherId, {
     onSuccess() {
       resetQueryData([GATHER_CONTENT]);
-      getScore(POINT_SYSTEM_PLUS.GATHER_ATTEND);
       completeToast("free", "참여가 완료되었습니다. 5 SCORE 획득 !");
     },
     onError: errorToast,

--- a/pageTemplates/gather/detail/GatherBottomNav.tsx
+++ b/pageTemplates/gather/detail/GatherBottomNav.tsx
@@ -6,11 +6,9 @@ import styled from "styled-components";
 
 import Slide from "../../../components/layouts/PageSlide";
 import { GATHER_CONTENT } from "../../../constants/keys/queryKeys";
-import { POINT_SYSTEM_PLUS } from "../../../constants/serviceConstants/pointSystemConstants";
 import { useResetQueryData } from "../../../hooks/custom/CustomHooks";
 import { useCompleteToast, useErrorToast } from "../../../hooks/custom/CustomToast";
 import { useGatherParticipationMutation } from "../../../hooks/gather/mutations";
-import { usePointSystemMutation } from "../../../hooks/user/mutations";
 import GatherExpireModal from "../../../modals/gather/gatherExpireModal/GatherExpireModal";
 import GatherParticipateModal from "../../../modals/gather/gatherParticipateModal/GatherParticipateModal";
 import { GatherStatus, IGather } from "../../../types/models/gatherTypes/gatherTypes";
@@ -36,12 +34,8 @@ function GatherBottomNav({ data }: IGatherBottomNav) {
 
   const resetQueryData = useResetQueryData();
 
-  const { mutate: getScore } = usePointSystemMutation("score");
-
   const { mutate: cancel } = useGatherParticipationMutation("delete", gatherId, {
     onSuccess() {
-      const score = POINT_SYSTEM_PLUS.GATHER_ATTEND;
-      getScore({ ...score, value: -score.value, message: "모임 참여 취소" });
       completeToast("free", "참여 신청이 취소되었습니다.", true);
       resetQueryData([GATHER_CONTENT]);
     },

--- a/pageTemplates/group/admin/GroupAdminInvitation.tsx
+++ b/pageTemplates/group/admin/GroupAdminInvitation.tsx
@@ -15,6 +15,7 @@ import { useAdminUsersLocationControlQuery } from "../../../hooks/admin/quries";
 import { useCompleteToast } from "../../../hooks/custom/CustomToast";
 import { useGroupWaitingStatusMutation } from "../../../hooks/groupStudy/mutations";
 import { IUserSummary } from "../../../types/models/userTypes/userInfoTypes";
+import { searchName } from "../../../utils/stringUtils";
 
 type UserType = "신규 가입자" | "전체";
 
@@ -53,11 +54,7 @@ export default function GroupAdminInvitation() {
     setFilterUsers(null);
     if (isLoading || !usersAll) return;
     if (nameValue) {
-      setFilterUsers(
-        usersAll.filter(
-          (user) => (user.isActive && user.name === nameValue) || user.name.slice(1) === nameValue,
-        ),
-      );
+      setFilterUsers(searchName(usersAll, nameValue));
     } else {
       setFilterUsers(
         usersAll.filter((user) =>

--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -1,3 +1,5 @@
+import { IUser, IUserSummary } from "../types/models/userTypes/userInfoTypes";
+
 export const findParentheses = (text: string) => {
   const regex = /\(.*?\)/g; // 'g' 플래그를 추가하여 모든 일치 항목을 찾습니다.
   const found = text.match(regex);
@@ -15,4 +17,10 @@ export const parseUrlToSegments = (url) => {
   const basePath = queryStartIndex >= 0 ? url.substring(0, queryStartIndex) : url;
   const segments = basePath.split("/").filter(Boolean);
   return segments;
+};
+
+export const searchName = (users: IUser[] | IUserSummary[], name: string) => {
+  return users.filter(
+    (user) => (user.isActive && user.name === name) || user.name.slice(1) === name,
+  );
 };


### PR DESCRIPTION
1. 유저 초대시 이름 입력해서 찾는 기능
2. 점수 부여 방식을 원래는 프론트에서 신청한 인원을 기준으로 점수를 추가하거나 감소시켰음. 그렇지만 모임에 초대를 받아서 가입한 경우에도 점수가 증가해야 했고, 이걸 한번 더 받는 사람 id 기준으로 찾는 것 보다는, 백엔드에서 모임에 추가되거나 제거될때마다 점수 조작과 로깅을 같이 해주는게 좋다고 판단. 백엔드 코드를 변경하고, 프론트 코드도 변경함
