### PR TITLE
design: StudyThumbnailCard, GatherThumbnailCard

### DIFF
--- a/components/atoms/badges/SolidBadge.tsx
+++ b/components/atoms/badges/SolidBadge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@chakra-ui/react";
+
+export function SolidBadge({ text, colorScheme }) {
+  return (
+    <Badge
+      px="8px"
+      py="4px"
+      h="fit-content"
+      w="fit-content"
+      borderRadius={4}
+      fontSize="12px"
+      variant="solid"
+      colorScheme={colorScheme}
+    >
+      {text}
+    </Badge>
+  );
+}

--- a/components/molecules/PlaceImage.tsx
+++ b/components/molecules/PlaceImage.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@chakra-ui/react";
-import { useSession } from "next-auth/react";
 import Image from "next/image";
+import { useSession } from "next-auth/react";
 
 import { useTogglePlaceHeart } from "../../hooks/custom/CustomHooks";
 import { useUserInfoQuery } from "../../hooks/user/queries";
@@ -26,7 +26,7 @@ function PlaceImage({ image, id, hasToggleHeart, selected }: PlaceHeartImageProp
   const isMyPrefer = preference?.place === id || preference?.subPlace?.includes(id);
 
   const toggleHeart = useTogglePlaceHeart();
-  
+
   return (
     <Box
       aspectRatio={1 / 1}
@@ -48,13 +48,18 @@ function PlaceImage({ image, id, hasToggleHeart, selected }: PlaceHeartImageProp
             ? "0px 5px 10px 0px #1BB8760A"
             : null
       }
+      w="100px"
+      h="100px"
     >
       <Image
         src={image.url}
         alt="thumbnailImage"
-        fill={true}
         sizes="100px"
+        fill
         priority={image?.isPriority}
+        style={{
+          objectFit: "cover",
+        }}
       />
       {selected === "main" && (
         <Box pos="absolute" top={1} right={1} color="white">
@@ -66,8 +71,8 @@ function PlaceImage({ image, id, hasToggleHeart, selected }: PlaceHeartImageProp
           pos="absolute"
           w="20px"
           h="20px"
-          bottom={0}
-          right={0}
+          bottom={2}
+          right={1}
           color="white"
           onClick={(e) => toggleHeart(e, preference, id, userLoading)}
         >

--- a/components/molecules/cards/GatherThumbnailCard.tsx
+++ b/components/molecules/cards/GatherThumbnailCard.tsx
@@ -1,0 +1,190 @@
+import { Box, Flex } from "@chakra-ui/react";
+import dayjs from "dayjs";
+import Image from "next/image";
+import Link from "next/link";
+import { ComponentProps } from "react";
+import styled from "styled-components";
+
+import { SingleLineText } from "../../../styles/layout/components";
+import { IImageProps } from "../../../types/components/assetTypes";
+import { ITextAndColorSchemes } from "../../../types/components/propTypes";
+import { UserSimpleInfoProps } from "../../../types/models/userTypes/userInfoTypes";
+import { dayjsToFormat } from "../../../utils/dateTimeUtils";
+import { SolidBadge } from "../../atoms/badges/SolidBadge";
+import AvatarGroupsOverwrap from "../groups/AvatarGroupsOverwrap";
+
+const VOTER_SHOW_MAX = 6;
+
+export interface IPostThumbnailCard {
+  participants?: UserSimpleInfoProps[];
+  title: string;
+  subtitle: string;
+  image: IImageProps;
+  url: string;
+  badge: ITextAndColorSchemes;
+  type: "study" | "gather";
+  statusText?: string;
+  maxCnt?: number;
+  func?: () => void;
+  registerDate?: string;
+  id?: string;
+  locationDetail?: string;
+}
+
+interface IPostThumbnailCardObj {
+  postThumbnailCardProps: IPostThumbnailCard;
+  isShort?: boolean;
+}
+
+export function GatherThumbnailCard({
+  postThumbnailCardProps: {
+    participants,
+    title,
+    subtitle,
+    image,
+    url,
+    badge,
+    statusText = undefined,
+    maxCnt = undefined,
+    func = undefined,
+    type,
+    registerDate,
+    locationDetail,
+    id,
+  },
+  isShort,
+}: IPostThumbnailCardObj) {
+  const userAvatarArr = participants
+    ?.filter((par) => par)
+    .map((par) => ({
+      image: par.profileImage,
+      ...(par.avatar?.type !== null ? { avatar: par.avatar } : {}),
+    }));
+
+  const CLOSED_TEXT_ARR = ["모집 마감", "닫힘"];
+
+  return (
+    <CardLink href={url} onClick={func}>
+      <PlaceImage src={image.url} priority={image.priority} />
+      <Flex direction="column" ml="12px" flex={1}>
+        {badge && <SolidBadge text={badge.text} colorScheme={badge.colorScheme} />}
+        <Title>{title}</Title>
+        <Subtitle>
+          <Box as="span" color="var(--color-mint)" mr={1}>
+            <i className="fa-solid fa-location-dot fa-sm" />
+          </Box>
+          {subtitle}
+        </Subtitle>
+        {participants ? (
+          <Flex alignItems="center" mt={1}>
+            <AvatarGroupsOverwrap
+              userAvatarArr={userAvatarArr}
+              maxCnt={VOTER_SHOW_MAX - (isShort ? 1 : 0)}
+            />
+
+            <Box
+              fontSize="14px"
+              color="var(--color-mint)"
+              fontWeight={600}
+              mr="8px"
+              mt="4px"
+              ml="auto"
+            >
+              {statusText}
+            </Box>
+            <Flex
+              mb="-2px"
+              fontSize="15px"
+              align="center"
+              color="var(--gray-500)"
+              letterSpacing="2px"
+            >
+              <i className="fa-solid fa-user fa-xs" />
+              <Flex ml="8px" align="center" fontWeight={500}>
+                <Box
+                  as="span"
+                  color={
+                    CLOSED_TEXT_ARR.includes(badge?.text)
+                      ? "inherit"
+                      : maxCnt && participants.length >= maxCnt
+                        ? "var(--color-red)"
+                        : "var(--gray-800)"
+                  }
+                >
+                  {participants.length}
+                </Box>
+                <Box as="span" mr="2px" ml="4px">
+                  /
+                </Box>
+                <span>{maxCnt || <i className="fa-regular fa-infinity" />}</span>
+              </Flex>
+            </Flex>
+          </Flex>
+        ) : (
+          <Flex mt="auto" color="var(--gray-500)">
+            <Box>등록일: </Box>
+            <Box>{dayjsToFormat(dayjs(registerDate), "YYYY년 M월 D일")}</Box>
+          </Flex>
+        )}
+      </Flex>
+    </CardLink>
+  );
+}
+
+type PlaceImageProps = Omit<ComponentProps<typeof Image>, "alt" | "sizes" | "fill">;
+
+function PlaceImage(props: PlaceImageProps) {
+  return (
+    <Box
+      aspectRatio={1 / 1}
+      borderRadius="var(--rounded-lg)"
+      position="relative"
+      overflow="hidden"
+      pos="relative"
+      w="120px"
+      h="120px"
+    >
+      <Image
+        {...props}
+        alt="thumbnailImage"
+        sizes="120px"
+        fill
+        style={{
+          objectFit: "cover",
+        }}
+      />
+    </Box>
+  );
+}
+
+const CardLink = styled(Link)`
+  height: fit-content;
+  display: flex;
+  padding: 8px;
+  border: var(--border);
+  border-radius: var(--rounded-lg);
+  background-color: white;
+  justify-content: space-between;
+
+  &:hover {
+    background-color: var(--gray-200);
+  }
+
+  &:not(:last-of-type) {
+    margin-bottom: 16px;
+  }
+`;
+
+const Title = styled(SingleLineText)`
+  font-weight: 600;
+  font-size: 16px;
+  margin-top: 8px;
+`;
+
+const Subtitle = styled(SingleLineText)`
+  color: var(--gray-500);
+  font-size: 12px;
+  width: 90%;
+  margin-top: 8px;
+  font-weight: 500;
+`;

--- a/components/molecules/cards/StudyThumbnailCard.tsx
+++ b/components/molecules/cards/StudyThumbnailCard.tsx
@@ -1,0 +1,161 @@
+import { Box, Flex } from "@chakra-ui/react";
+import dayjs from "dayjs";
+import Link from "next/link";
+import styled from "styled-components";
+
+import { SingleLineText } from "../../../styles/layout/components";
+import { IImageProps } from "../../../types/components/assetTypes";
+import { ITextAndColorSchemes } from "../../../types/components/propTypes";
+import { UserSimpleInfoProps } from "../../../types/models/userTypes/userInfoTypes";
+import { dayjsToFormat } from "../../../utils/dateTimeUtils";
+import { SolidBadge } from "../../atoms/badges/SolidBadge";
+import AvatarGroupsOverwrap from "../groups/AvatarGroupsOverwrap";
+import PlaceImage from "../PlaceImage";
+
+const VOTER_SHOW_MAX = 6;
+
+export interface IPostThumbnailCard {
+  participants?: UserSimpleInfoProps[];
+  title: string;
+  subtitle: string;
+  image: IImageProps;
+  url: string;
+  badge: ITextAndColorSchemes;
+  type: "study" | "gather";
+  statusText?: string;
+  maxCnt?: number;
+  func?: () => void;
+  registerDate?: string;
+  id?: string;
+  locationDetail?: string;
+}
+
+interface IPostThumbnailCardObj {
+  postThumbnailCardProps: IPostThumbnailCard;
+  isShort?: boolean;
+}
+
+export function StudyThumbnailCard({
+  postThumbnailCardProps: {
+    participants,
+    title,
+    subtitle,
+    image,
+    url,
+    badge,
+    statusText = undefined,
+    maxCnt = undefined,
+    func = undefined,
+    type,
+    registerDate,
+    locationDetail,
+    id,
+  },
+  isShort,
+}: IPostThumbnailCardObj) {
+  const userAvatarArr = participants
+    ?.filter((par) => par)
+    .map((par) => ({
+      image: par.profileImage,
+      ...(par.avatar?.type !== null ? { avatar: par.avatar } : {}),
+    }));
+
+  const CLOSED_TEXT_ARR = ["모집 마감", "닫힘"];
+
+  return (
+    <CardLink href={url} onClick={func}>
+      <PlaceImage image={{ url: image.url, isPriority: image.priority }} hasToggleHeart id={id} />
+      <Flex direction="column" ml="12px" flex={1}>
+        {badge && <SolidBadge text={badge.text} colorScheme={badge.colorScheme} />}
+        <Title>{title}</Title>
+        <Subtitle>
+          <Box as="span" color="var(--color-mint)" mr={1}>
+            <i className="fa-solid fa-location-dot fa-sm" />
+          </Box>
+          {subtitle}
+        </Subtitle>
+        {participants ? (
+          <Flex alignItems="center" mt={2}>
+            <AvatarGroupsOverwrap
+              userAvatarArr={userAvatarArr}
+              maxCnt={VOTER_SHOW_MAX - (isShort ? 1 : 0)}
+            />
+
+            <Box
+              fontSize="14px"
+              color="var(--color-mint)"
+              fontWeight={600}
+              mr="8px"
+              mt="4px"
+              ml="auto"
+            >
+              {statusText}
+            </Box>
+            <Flex
+              mb="-2px"
+              fontSize="15px"
+              align="center"
+              color="var(--gray-500)"
+              letterSpacing="2px"
+            >
+              <i className="fa-solid fa-user fa-xs" />
+              <Flex ml="8px" align="center" fontWeight={500}>
+                <Box
+                  as="span"
+                  color={
+                    CLOSED_TEXT_ARR.includes(badge?.text)
+                      ? "inherit"
+                      : maxCnt && participants.length >= maxCnt
+                        ? "var(--color-red)"
+                        : "var(--gray-800)"
+                  }
+                >
+                  {participants.length}
+                </Box>
+                <Box as="span" mr="2px" ml="4px">
+                  /
+                </Box>
+                <span>{maxCnt || <i className="fa-regular fa-infinity" />}</span>
+              </Flex>
+            </Flex>
+          </Flex>
+        ) : (
+          <Flex mt="auto" color="var(--gray-500)">
+            <Box>등록일: </Box>
+            <Box>{dayjsToFormat(dayjs(registerDate), "YYYY년 M월 D일")}</Box>
+          </Flex>
+        )}
+      </Flex>
+    </CardLink>
+  );
+}
+
+const CardLink = styled(Link)`
+  height: fit-content;
+  display: flex;
+  padding: 16px 0;
+  background-color: white;
+  justify-content: space-between;
+
+  &:hover {
+    background-color: var(--gray-200);
+  }
+
+  &:not(:last-of-type) {
+    border-bottom: var(--border);
+  }
+`;
+
+const Title = styled(SingleLineText)`
+  margin-top: 8px;
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const Subtitle = styled(SingleLineText)`
+  color: var(--gray-500);
+  font-size: 12px;
+  width: 90%;
+  font-weight: 500;
+  margin-top: 4px;
+`;

--- a/components/molecules/groups/AvatarGroupsOverwrap.tsx
+++ b/components/molecules/groups/AvatarGroupsOverwrap.tsx
@@ -14,14 +14,11 @@ interface IAvatarGroupsOverwrap {
   maxCnt?: number;
 }
 
-
-
 export default function AvatarGroupsOverwrap({
   userAvatarArr,
   userLength,
   maxCnt,
 }: IAvatarGroupsOverwrap) {
-
   return (
     <Participants>
       {userAvatarArr.map((att, idx) => {
@@ -31,7 +28,7 @@ export default function AvatarGroupsOverwrap({
               key={idx}
               image={att.image}
               avatar={att.avatar}
-              size="sm"
+              size="xs"
               isLink={false}
               shadowAvatar={
                 idx === maxCnt - 1 &&

--- a/components/organisms/CardColumnLayout.tsx
+++ b/components/organisms/CardColumnLayout.tsx
@@ -25,9 +25,7 @@ export function CardColumnLayout({
   return (
     <Layout>
       {cardDataArr.map((cardData, idx) => (
-        <Item key={idx}>
-          <PostThumbnailCard postThumbnailCardProps={cardData} isShort={isShort} />
-        </Item>
+        <PostThumbnailCard key={idx} postThumbnailCardProps={cardData} isShort={isShort} />
       ))}
       {cardDataArr?.length >= 3 && <ShadowBlockButton text="더보기" url={url} func={func} />}
     </Layout>
@@ -50,8 +48,4 @@ export function CardColumnLayoutSkeleton() {
 const Layout = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const Item = styled.div`
-  margin-bottom: 16px;
 `;

--- a/pageTemplates/home/HomeGatherCol.tsx
+++ b/pageTemplates/home/HomeGatherCol.tsx
@@ -1,14 +1,13 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useSetRecoilState } from "recoil";
 
+import ShadowBlockButton from "../../components/atoms/buttons/ShadowBlockButton";
+import { GatherThumbnailCard } from "../../components/molecules/cards/GatherThumbnailCard";
 import { IPostThumbnailCard } from "../../components/molecules/cards/PostThumbnailCard";
-import {
-  CardColumnLayout,
-  CardColumnLayoutSkeleton,
-} from "../../components/organisms/CardColumnLayout";
+import { CardColumnLayoutSkeleton } from "../../components/organisms/CardColumnLayout";
 import { useGatherQuery } from "../../hooks/gather/queries";
 import { slideDirectionState } from "../../recoils/navigationRecoils";
 import { transferGatherDataState } from "../../recoils/transferRecoils";
@@ -37,18 +36,23 @@ export default function HomeGatherCol() {
   }, [gathers]);
 
   return (
-    <Box mb="24px">
-      <Box>
-        {cardDataArr.length ? (
-          <CardColumnLayout
-            cardDataArr={cardDataArr}
-            url={`/gather?location=${location}`}
-            func={() => setSlideDirection("right")}
-          />
-        ) : (
-          <CardColumnLayoutSkeleton />
-        )}
-      </Box>
+    <Box my="24px">
+      {cardDataArr ? (
+        <Flex direction="column">
+          {cardDataArr.map((cardData, idx) => (
+            <GatherThumbnailCard key={idx} postThumbnailCardProps={cardData} />
+          ))}
+          {cardDataArr.length >= 3 && (
+            <ShadowBlockButton
+              text="더보기"
+              url={`/gather?location=${location}`}
+              func={() => setSlideDirection("right")}
+            />
+          )}
+        </Flex>
+      ) : (
+        <CardColumnLayoutSkeleton />
+      )}
     </Box>
   );
 }

--- a/pageTemplates/home/study/StudyCardCol.tsx
+++ b/pageTemplates/home/study/StudyCardCol.tsx
@@ -1,16 +1,15 @@
-import { ThemeTypings } from "@chakra-ui/react";
+import { Flex, ThemeTypings } from "@chakra-ui/react";
 import dayjs from "dayjs";
-import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 
+import ShadowBlockButton from "../../../components/atoms/buttons/ShadowBlockButton";
 import BlurredPart from "../../../components/molecules/BlurredPart";
 import { IPostThumbnailCard } from "../../../components/molecules/cards/PostThumbnailCard";
-import {
-  CardColumnLayout,
-  CardColumnLayoutSkeleton,
-} from "../../../components/organisms/CardColumnLayout";
+import { StudyThumbnailCard } from "../../../components/molecules/cards/StudyThumbnailCard";
+import { CardColumnLayoutSkeleton } from "../../../components/organisms/CardColumnLayout";
 import { STUDY_CHECK_POP_UP, STUDY_VOTING_TABLE } from "../../../constants/keys/localStorage";
 import { LOCATION_RECRUITING, LOCATION_TO_FULLNAME } from "../../../constants/location";
 import {
@@ -23,7 +22,6 @@ import {
   StudyParticipationProps,
   StudyStatus,
 } from "../../../types/models/studyTypes/studyDetails";
-
 import { StudyVotingSave } from "../../../types/models/studyTypes/studyInterActions";
 import { InactiveLocation, LocationEn } from "../../../types/services/locationTypes";
 import { convertLocationLangTo } from "../../../utils/convertUtils/convertDatas";
@@ -114,10 +112,17 @@ function StudyCardCol({ participations, date }: StudyCardColProps) {
         size="lg"
       >
         {studyCardColData ? (
-          <CardColumnLayout
-            cardDataArr={studyCardColData}
-            url={`/studyList?tab=study&location=${locationEn}&date=${date}`}
-          />
+          <Flex direction="column">
+            {studyCardColData.map((cardData, idx) => (
+              <StudyThumbnailCard key={idx} postThumbnailCardProps={cardData} />
+            ))}
+            {studyCardColData.length >= 3 && (
+              <ShadowBlockButton
+                text="더보기"
+                url={`/studyList?tab=study&location=${locationEn}&date=${date}`}
+              />
+            )}
+          </Flex>
         ) : (
           <CardColumnLayoutSkeleton />
         )}
@@ -139,7 +144,6 @@ export const setStudyDataToCardCol = (
   urlDateParam: string,
   uid: string,
 ): IPostThumbnailCard[] => {
- 
   const cardColData: IPostThumbnailCard[] = [...studyData]
     ?.sort((a, b) =>
       a.place.branch === "개인 스터디" ? 1 : b.place.branch === "개인 스터디" ? -1 : 0,


### PR DESCRIPTION
## How to check
- 홈화면으로 가면 확인할 수 있습니다!

- `StudyThumbnailCard`
<img width="421" alt="스크린샷 2024-10-12 16 23 53" src="https://github.com/user-attachments/assets/4ed9cc62-3670-4138-ad36-5e1b3de33de5">

- `GatherThumbnailCard`
<img width="399" alt="스크린샷 2024-10-12 16 24 02" src="https://github.com/user-attachments/assets/0f30bbc2-319c-4f83-b6ba-6e02ee51b507">

## PR Point
- `StudyThumbnailCard` 와 `GatherThumbnailCard` 모두 `PostThumbnailCard` 의 `props` 를 동일하게 받습니다.
- **`CardColunmLayout` 이 `PostThumbnailCard` 에 의존하고 있어서요.** 그래서 `StudyCol` 와 `GatherCol` 에서 `CardColunmLayout` 를 사용하지 않았어요. 대신 `CardColunmLayout` 내 UI 를 밖으로 빼두었어요.
  - [pageTemplates/home/HomeGatherCol.tsx](https://github.com/AboutClan/About/pull/229/files#diff-1ca904639a4d27b3dfbb216b41c2ab46796de1e29aef516551399903c56d1c95)
  - [pageTemplates/home/study/StudyCardCol.tsx](https://github.com/AboutClan/About/pull/229/files#diff-cb6f9ee5bbb459ee7d365f2755ce0b9b1124aae590191bcc6d669427e759ba30)