### PR TITLE
fix(StudyPageDrawer): prevent scroll chaining

### DIFF
--- a/components/organisms/drawer/BottomFlexDrawer.tsx
+++ b/components/organisms/drawer/BottomFlexDrawer.tsx
@@ -11,6 +11,8 @@ export const DRAWER_MIN_HEIGHT = 40;
 //적당한 값 조율해야 함
 export const MAX_DRAG_DISTANCE = 40;
 
+const SWIPE_THRESHOLD = 40; // 스와이프 임계값
+
 export interface BottomFlexDrawerOptions {
   header?: {
     title: string;
@@ -40,18 +42,14 @@ export default function BottomFlexDrawer({
   drawerOptions,
   children,
   isDrawerUp,
-  height,
+  height: maxHeight,
   zIndex,
 
   isOverlay,
 }: BottomFlexDrawerProps) {
-  const maxHeight = height;
-
   const [drawerHeight, setDrawerHeight] = useState(isDrawerUp ? maxHeight : DRAWER_MIN_HEIGHT); // 초기 높이
   const startYRef = useRef(0); // 드래그 시작 위치 저장
   const currentHeightRef = useRef(drawerHeight); // 현재 높이 저장
-
-  const SWIPE_THRESHOLD = 40; // 스와이프 임계값
 
   useEffect(() => {
     if (isDrawerUp) setDrawerHeight(maxHeight);
@@ -70,7 +68,7 @@ export default function BottomFlexDrawer({
     const deltaY = startYRef.current - currentY;
     let newHeight = currentHeightRef.current + deltaY;
 
-    // 최대 드래그 범위를 30px로 제한
+    // 최대 드래그 범위를 40px로 제한
     const maxDragHeight = currentHeightRef.current + MAX_DRAG_DISTANCE;
     const minDragHeight = currentHeightRef.current - MAX_DRAG_DISTANCE;
     newHeight = Math.max(Math.min(newHeight, maxDragHeight), minDragHeight);
@@ -88,9 +86,7 @@ export default function BottomFlexDrawer({
     if (deltaY > SWIPE_THRESHOLD) {
       setDrawerHeight(maxHeight); // 위로 쭉 올라가는 동작
     } else if (deltaY < -SWIPE_THRESHOLD) {
-      if (setIsModal) {
-        setIsModal(false);
-      }
+      setIsModal(false);
 
       setDrawerHeight(DRAWER_MIN_HEIGHT); // 아래로 내려가는 동작
     } else {

--- a/pageTemplates/studyPage/StudyPageDrawer.tsx
+++ b/pageTemplates/studyPage/StudyPageDrawer.tsx
@@ -101,7 +101,7 @@ function StudyPageDrawer({
           setSelectOption={setSelectOption}
           placeCnt={thumbnailCardInfoArr?.length}
         />
-        <Box overflowY="scroll" h="66.5%">
+        <Box overflowY="scroll" overscrollBehaviorY="contain" h="66.5%">
           {thumbnailCardInfoArr
             ? thumbnailCardInfoArr.map(({ participants, ...thumbnailCardInfo }, idx) => (
                 <Box key={idx} mb={3}>


### PR DESCRIPTION
## 문제상황
- StudyPageDrawer 의 카페리스트를 스크롤할 때 스크롤이 안되는 현상

## 원인
- 스크롤 상단이나 하단에서 스크롤이 멈추면 스크롤 행위가 상위 요소로 전파(bounce effect)돼서 생긴 문제. scroll chaning 이라고 함 (브라우저 기본 동작)
- 스크롤 상단/하단에서 스크롤 제스처를 할 경우, 상위로 스크롤이 전파되는데 **스크롤이 해제되기도 전에 빠르게 스크롤 제스처를 해서 스크롤이 안되는 것처럼 보였던 것임. 중요한건 빠르게 했기 때문에 생긴 것.** 반대로 느리게 하면 정상 동작함.

## 해결
- 스크롤 상단/하단에서 스크롤 제스처를 취하더라도 스크롤이 전파되지 않도록 수정
- `overflow: scroll` 인 요소에서 이런 전파효과를 제거해주면 됨

```css
overscroll-behavior: contain;
```

### AS-IS

https://github.com/user-attachments/assets/44a85959-f28a-4c7d-a519-4f76cfeddbff


### TO-BE

https://github.com/user-attachments/assets/442c3836-a109-4b65-8dc2-7c177199aa58

## Refs

- https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior